### PR TITLE
On 'View DICOM fields' click, remove dicom edit table if it already exists

### DIFF
--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -102,6 +102,11 @@ class dicom_deidentifier_frame_gui(Frame):
         return self.dirname
 
     def deidentify(self):
+
+        # clear edit table if it exists
+        if hasattr(self, 'field_edit_win'):
+            self.field_edit_win.destroy()
+
         # Read the XML file with the identifying DICOM fields
         load_xml = PathMethods.resource_path("data/fields_to_zap.xml")
         XML_filename  = load_xml.return_path()


### PR DESCRIPTION
This fix was implemented by Tara Campbell during OHBM Brain Hack 2016.