### PR TITLE
PyDICOM requirements displayed in dicom anonymizer tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,25 @@ To open DICAT, simply double click on the executable.
 
 ### From the source code
 
-To install DICAT source code on a computer, download and save the content of the current Github repository into a workstation.
+######Requirements: 
 
 Before running DICAT, make sure your systems contains a [Python](https://www.python.org) compiler with the [TkInter](https://wiki.python.org/moin/TkInter) library (usually, TkInter comes by default with most Python installations).
 
 For Ubuntu distributions, TkInter can be installed via apt-get:
 ```sudo apt-get install python-tk```
 
-The [PyDICOM](http://www.pydicom.org) package is also required by DICAT.
+The [PyDICOM](https://pydicom.readthedocs.io/en/stable/getting_started.html#installing) package is also required by DICAT. 
+
+For most platform, PyDICOM can be installed via easy_install: 
+```sudo easy_install pydicom``` 
+
+
+######DICAT installation
+
+
+To install DICAT source code on a computer, download and save the content of the current Github repository into a workstation.
 
 DICAT can be started by executing `DICAT.py` script with a Python compiler. On UNIX computers (Linux and Mac OS X), open a terminal, go to the main directory of DICAT source code (`dicat` directory) and run the following:
-
 ```python DICAT.py```
 
 

--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -14,17 +14,6 @@ created application would not find them.
 import lib.resource_path_methods as PathMethods
 
 
-'''
-Determine which de-identifier tool to use (PyDICOM or DICOM toolkit) before
-starting the program.
-Will exit with an error message if neither PyDICOM or DICOM toolkit were found.
-'''
-deidentifier_tool = methods.find_deidentifier_tool()
-if not deidentifier_tool:
-    message = "Error: no tool was found to read or de-identify DICOM files."
-    tkMessageBox.showinfo("Message", message)
-    exit()
-
 
 class dicom_deidentifier_frame_gui(Frame):
     def __init__(self, parent):
@@ -33,6 +22,15 @@ class dicom_deidentifier_frame_gui(Frame):
         self.dir_opt = {}
         self.field_dict = {}
         self.message = StringVar()
+
+        # Determine which de-identifier tool to use (PyDICOM or DICOM toolkit) before
+        # starting the program.
+        deidentifier_tool = methods.find_deidentifier_tool()
+        if deidentifier_tool:
+            error = "ERROR: no tool was found to read or de-identify DICOM files. \n " + \
+                    "Please make sure PyDICOM has been properly installed."
+            self.message.set(error)
+
         self.initialize()
 
 
@@ -88,7 +86,13 @@ class dicom_deidentifier_frame_gui(Frame):
                                padx=(0, 10),
                                sticky=E + W
                              )
-        self.messageView.grid_forget()
+        if not self.message.get():
+            # if error message is set due to not finding the tool, show the error on the screen
+            self.messageView.configure(fg="dark red",
+                                       font="Helvetica 16 bold italic"
+                                       )
+        else:
+            self.messageView.grid_forget()
 
     def askdirectory(self):
 


### PR DESCRIPTION
This allows to be able to use the other functionalities of DICAT even though a DICOM anonymizer tool was not found. Aka, could use the ID Mapper as well as the scheduler (once the later will be finished)

See issue #78
