### PR TITLE
added an entry with a s at the end of OtherPatientName

### DIFF
--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -96,6 +96,11 @@
       <editable>no</editable>
     </item>
     <item>
+      <name>0010,1001</name>
+      <description>OtherPatientNames</description>
+      <editable>no</editable>
+    </item>
+    <item>
       <name>0010,0021</name>
       <description>IssuerOfPatientID</description>
       <editable>no</editable>


### PR DESCRIPTION
Tested on PHI data set.

I'm not sure if the second <name>0010,1001</name> just overwrites the first one or both are being removed if both present.