### PR TITLE
[DICOM deidentifier] Removing leading and trailing spaces from PatientName and other DICOM fields

### DIFF
--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -329,7 +329,7 @@ def pydicom_zapping(dicom_file, dicom_fields):
     for name in dicom_fields:
         new_val = ""
         if 'Value' in dicom_fields[name]:
-            new_val = dicom_fields[name]['Value']
+            new_val = dicom_fields[name]['Value'].strip()
 
         if dicom_fields[name]['Editable'] is True:
             try:
@@ -446,10 +446,9 @@ def create_directories(dicom_folder, dicom_fields, subdirs_list):
 
     # Create an original_dcm and deidentified_dcm directory in the DICOM folder,
     # as well as subdirectories
-    original_dir = dicom_folder + os.path.sep + dicom_fields['0010,0010'][
-        'Value']
-    deidentified_dir = dicom_folder + os.path.sep + dicom_fields['0010,0010'][
-        'Value'] + "_deidentified"
+    patient_name     = dicom_fields['0010,0010']['Value'].strip()
+    original_dir     = dicom_folder + os.path.sep + patient_name
+    deidentified_dir = dicom_folder + os.path.sep + patient_name + "_deidentified"
     os.mkdir(original_dir, 0755)
     os.mkdir(deidentified_dir, 0755)
     # Create subdirectories in original and de-identified directory, as found in


### PR DESCRIPTION
This PR fixes a bug when PatientName contains leading and trailing spaces. 

Before when running the DICOM deindentifier on a study where new `PatientName` is `   new_name   `, we ended up with the two following folders:
- `   new_name   .zip`
- `   new_name   _deidentify.zip`
In addition, it added leading and trailing spaces in the DICOM headers.

Now, leading and trailing spaces are removed from the new DICOM values to edit when they are present. So now where a new `PatientName` is `   new_name   `, folders are named:
- `   new_name   .zip`
- `   new_name   _deidentify.zip`