### PR TITLE
Added possibility to keep or edit any of the DICOM field value

### DIFF
--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import Tkinter, tkFileDialog, tkMessageBox
+import Tkinter, tkFileDialog, tkMessageBox, ttk
 import os
 from Tkinter import *
 
@@ -51,48 +51,39 @@ class dicom_deidentifier_frame_gui(Frame):
 
         # Create an entry with a default text that will be replaced by the path
         # to the directory once directory selected
-        self.entry = Entry(self.frame,
-                           width=40,
-                           textvariable=self.entryVariable
-                          )
+        self.entry = Entry(
+            self.frame, width=40, textvariable=self.entryVariable
+        )
         self.entry.focus_set()
         self.entry.selection_range(0, Tkinter.END)
 
         # Create a select button to use to select a DICOM directory
-        self.buttonSelect = Button(self.frame,
-                                   text=u"Select",
-                                   command=self.askdirectory
-                                  )
+        self.buttonSelect = Button(
+            self.frame, text=u"Select", command=self.askdirectory
+        )
         self.buttonsPanel = Frame(self.frame)
 
         self.entry.grid(row=0, column=0, padx=15, pady=10, sticky=E + W)
-        self.buttonSelect.grid(row=0,
-                               column=1,
-                               padx=(0, 15),
-                               pady=10,
-                               sticky=E + W)
+        self.buttonSelect.grid(
+            row=0, column=1, padx=(0, 15), pady=10, sticky=E + W
+        )
         self.buttonsPanel.grid(row=1, column=0, columnspan=2, pady=(4, 16))
 
-        self.buttonView = Button(self.buttonsPanel,
-                                 text=u"View DICOM fields",
-                                 command=self.deidentify)
+        self.buttonView = Button(
+            self.buttonsPanel, text=u"View DICOM fields", command=self.deidentify
+        )
         self.buttonView.grid(row=0, column=0, padx=(0, 10), sticky=E + W)
         self.buttonView.configure(state=DISABLED)
 
-        self.messageView = Label( self.frame,
-                                  textvariable=self.message,
-                                )
-        self.messageView.grid( row=2,
-                               column=0,
-                               columnspan=2,
-                               padx=(0, 10),
-                               sticky=E + W
-                             )
+        self.messageView = Label(self.frame, textvariable=self.message)
+        self.messageView.grid(
+            row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W
+        )
         if self.message.get():
             # if error message is set due to not finding the tool, show the error on the screen
-            self.messageView.configure(fg="dark red",
-                                       font="Helvetica 16 bold italic"
-                                       )
+            self.messageView.configure(
+                fg="dark red", font="Helvetica 16 bold italic"
+            )
         else:
             self.messageView.grid_forget()
 
@@ -112,6 +103,7 @@ class dicom_deidentifier_frame_gui(Frame):
         # clear edit table if it exists
         if hasattr(self, 'field_edit_win'):
             self.field_edit_win.destroy()
+            self.info_message.destroy()
 
         # Remove the message from the grid
         self.messageView.grid_forget()
@@ -127,6 +119,31 @@ class dicom_deidentifier_frame_gui(Frame):
             message = "No valid DICOM file was found in " + self.dirname
             tkMessageBox.showinfo("Error", message)
 
+        # print out a warning message at the top of the table
+        self.topPanel = Tkinter.Frame(self.parent)
+        self.topPanel.pack(fill='both', expand=1)
+
+        info_bold_msg = "WARNING: Every value present in the 'Value in DICOM file'" \
+                        "column will be written in the DICOM headers.\n"
+        info_body_msg = "To erase all header values from the DICOMs: " \
+                        "  1) click on 'Clear All Fields' " \
+                        "  2) enter the new PatientName for the study " \
+                        "  3) click on 'De-identify'"
+
+        self.info_msg = Text(self.topPanel, padx=40, wrap='word', height=3)
+        self.info_msg.tag_configure('bold',    font=('Verdana', 12, 'bold'), foreground='red2')
+        self.info_msg.tag_configure('default', font=('Verdana', 12),         foreground='red2')
+        self.info_msg.insert(END, info_bold_msg, 'bold')
+        self.info_msg.insert(END, info_body_msg, 'default')
+
+        self.scrollTopPanel = Scrollbar(self.topPanel, command=self.info_msg.yview)
+        self.info_msg.configure(yscrollcommand=self.scrollTopPanel.set)
+
+        self.info_msg.pack(fill='both', side="left", expand=1)
+        self.scrollTopPanel.pack(fill='y', side='right')
+        self.info_msg.config(state='disabled')
+
+
         fields_keys = list(field_dict.keys())
         keys_length = len(fields_keys) + 1
         self.edited_entries = [Tkinter.StringVar() for i in range(keys_length)]
@@ -135,90 +152,98 @@ class dicom_deidentifier_frame_gui(Frame):
             self.field_edit_win.pack(expand=1, fill='both')
             self.field_edit_win.columnconfigure(0, weight=1)
             self.field_edit_win.columnconfigure(1, weight=1)
+            self.field_edit_win.columnconfigure(2, weight=1)
             self.field_edit_win.rowconfigure(0, weight=1)
             self.field_edit_win.rowconfigure(1, weight=1)
 
-            # Set column names
-            self.field_edit_win.Name_field = Tkinter.Label(self.field_edit_win,
-                                                           text="Dicom Field",
-                                                           relief="ridge",
-                                                           width=30,
-                                                           anchor="w",
-                                                           fg="white",
-                                                           bg="#282828")
-            self.field_edit_win.Name_field.grid(column=0,
-                                                row=0,
-                                                padx=(5, 0),
-                                                pady=(5, 0),
-                                                sticky=N + S + W + E)
+            # set column names
+            self.keep_all = 0
+            self.field_edit_win.Name_field = Tkinter.Label(
+                self.field_edit_win, text="DICOM field name", relief="sunken",
+                width=30,            anchor="w",              fg="white",
+                bg="#282828",        height=2
+            )
             self.field_edit_win.Name_value = Tkinter.Label(
-                self.field_edit_win,
-                text="Value in Dicom",
-                relief="ridge",
-                width=55,
-                anchor="w",
-                fg="white",
-                bg="#282828")
-            self.field_edit_win.Name_value.grid(column=1,
-                                                row=0,
-                                                padx=(0, 5),
-                                                pady=(5, 0),
-                                                sticky=N + S + W + E)
+                self.field_edit_win, text="Value in DICOM file", relief="sunken",
+                width=55,            anchor="w",                 fg="white",
+                bg="#282828",        height=2
+            )
+
+            # display the column names on the grid
+            self.field_edit_win.Name_field.grid(
+                column=0, row=0, padx=(5, 0), sticky='nsew'
+            )
+            self.field_edit_win.Name_value.grid(
+                column=1, row=0, padx=(0, 0), sticky='nsew'
+            )
 
             # Display description of fields to zap in first column
             self.key_index = 1
             for keys in fields_keys:
+
+                # set the Editable of the dictionary to True for all entries now
+                # that they are all editable in the GUI. Note, the reason we don't
+                # modify the XML here is so that the mass_deidentifier can still
+                # run with only PatientName, DoB and Gender as editable
+                field_dict[keys]['Editable'] = True
+
+                # set DICOM field names and DICOM values
+                label_text  = str(field_dict[keys]['Description']) + ":"
+                pname_color = "black"
+                if label_text == 'PatientName:':
+                    label_text += ' (IDs to label the scan are required)'
+                    pname_color = "#006400"
                 self.field_edit_win.Field_label = Tkinter.Label(
+                    self.field_edit_win, text=label_text, relief='ridge',
+                    width=30,            anchor="w",      fg=pname_color,
+                    bg='#C0C0C0'
+                )
+                self.field_edit_win.Field = Tkinter.Entry(
                     self.field_edit_win,
-                    text=str(field_dict[keys]['Description']) + ':',
-                    relief="ridge", width=30, anchor="w", fg="black",
-                    bg="#B0B0B0")
-                self.field_edit_win.Field_label.grid(column=0,
-                                                     row=self.key_index,
-                                                     padx=(5, 0),
-                                                     sticky=N + S + W + E)
-                # Enter value to modify
-                if not field_dict[keys]['Editable']:  # kr#
-                    var = Tkinter.StringVar()
-                    self.field_edit_win.Field = Tkinter.Entry(
-                        self.field_edit_win, textvariable=var, state="disable",
-                        width=55)
-                    if 'Value' in field_dict[keys]:
-                        var.set(field_dict[keys]['Value'])
+                    textvariable=self.edited_entries[self.key_index],
+                    width=55,
+                )
+                if pname_color == "#006400":
+                    self.field_edit_win.Field.configure(
+                        highlightbackground=pname_color
+                    )
+
+                # display the values found in the DICOM file into the Entry field
+                if 'Value' in field_dict[keys]:
+                    self.edited_entries[self.key_index].set(
+                        field_dict[keys]['Value']
+                    )
                 else:
-                    self.field_edit_win.Field = Tkinter.Entry(
-                        self.field_edit_win,
-                        textvariable=self.edited_entries[self.key_index],
-                        width=55)
-                    if 'Value' in field_dict[keys]:
-                        self.field_edit_win.Field.insert(self.key_index,
-                                                         field_dict[keys][
-                                                             'Value'])
-                    else:
-                        self.field_edit_win.Field.insert(self.key_index, "")
-                self.field_edit_win.Field.grid(column=1, row=self.key_index,
-                                               padx=(0, 5),
-                                               sticky=N + S + W + E)
+                    self.edited_entries[self.key_index].set("")
+
+                # display table content
+                self.field_edit_win.Field_label.grid(
+                    column=0, row=self.key_index, padx=(5, 0), sticky='nsew'
+                )
+                self.field_edit_win.Field.grid(
+                    column=1, row=self.key_index, padx=(0, 0), sticky='nsew'
+                )
                 self.field_edit_win.rowconfigure(self.key_index, weight=1)
                 self.key_index += 1
 
             self.field_dict = field_dict
 
             self.bottomPanel = Tkinter.Frame(self.field_edit_win)
-            self.bottomPanel.grid(row=self.key_index, column=0, columnspan=2,
-                                  pady=10)
+            self.bottomPanel.grid(
+                row=self.key_index, column=0, columnspan=3, pady=10
+            )
 
             self.field_edit_win.button_done = Tkinter.Button(
                 self.bottomPanel,
                 text=u"De-identify",
-                command=self.collect_edited_data)
-            self.field_edit_win.button_done.grid(column=0, row=0, padx=20)
+                command=self.collect_edited_data
+            )
+            self.field_edit_win.button_done.grid(column=1, row=0, padx=20)
 
-            self.field_edit_win.buttonClear = Tkinter.Button(self.bottomPanel,
-                                                             text=u"Clear",
-                                                             command=self.clear,
-                                                             width=8)
-            self.field_edit_win.buttonClear.grid(column=1, row=0, padx=20)
+            self.field_edit_win.buttonClear = Tkinter.Button(
+                self.bottomPanel, text=u"Clear All Fields", command=self.clear
+            )
+            self.field_edit_win.buttonClear.grid(column=2, row=0, padx=20)
 
     def clear(self):
         for items in self.edited_entries:
@@ -269,3 +294,6 @@ class dicom_deidentifier_frame_gui(Frame):
                                    padx=(0, 10),
                                    sticky=E+W
                                  )
+
+
+

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -117,11 +117,14 @@ def grep_dicom_fields(xml_file):
     xmldoc = ET.parse(xml_file)
     dicom_fields = {}
     for item in xmldoc.findall('item'):
-        name = item.find('name').text
+        dicom_tag = item.find('name').text
         description = item.find('description').text
         editable = True if (item.find('editable').text == "yes") else False
-        dicom_fields[name] = {"Description": description, "Editable": editable}
-        # dicom_fields[name] = {"Description": description}
+        dicom_fields[dicom_tag] = {
+            "DICOM_tag"  : dicom_tag,
+            "Description": description,
+            "Editable"   : editable
+        }
 
     return dicom_fields
 

--- a/dicat/welcome_frame.py
+++ b/dicat/welcome_frame.py
@@ -62,7 +62,8 @@ class welcome_frame_gui(Frame):
         anonymizer  = '''
         1) select a DICOM directory
         2) view the DICOM headers information
-        3) run the de-identifier tool on all DICOMs of the selected directory
+        3) edit or clear the DICOM headers information directly in the table
+        4) run the de-identifier tool on all DICOMs of the selected directory with the edited information
         '''
         text.insert(END, anonymizer, 'default')
 


### PR DESCRIPTION
Several users asked for the possibility to keep the DICOM values and only edit certain values. In this PR, all fields are editable. In order to wipe all identifying information, one will need to first click on the "Clear All Fields" button, then enter the new PatientName and click on "De-identify".

![Screen Shot 2019-05-17 at 11 11 34 AM](https://user-images.githubusercontent.com/1402456/57937748-94e46600-7894-11e9-8952-75f62262eaa6.png)


This fixes: https://github.com/aces/DICAT/issues/99