### PR TITLE
Updated the PyDICOM link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ by default with most Python installations).
 For Ubuntu distributions, TkInter can be installed via apt-get:
 ```sudo apt-get install python-tk```
 
-The [PyDICOM](https://pydicom.readthedocs.io/en/stable/getting_started.html#installing) 
+The [PyDICOM](https://pydicom.github.io/pydicom/stable/getting_started.html#installing) 
 package is also required by DICAT. 
 
 For most platform, PyDICOM can be installed via easy_install: 


### PR DESCRIPTION
PyDICOM documentation has been moved to https://pydicom.github.io/pydicom/stable/getting_started.html#installing. This PR updates the link to the PyDIOM documentation in the README.md of DICAT.