### PR TITLE
Catch permission denied when creating folders

### DIFF
--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -279,11 +279,19 @@ class dicom_deidentifier_frame_gui(Frame):
 
             self.field_edit_win.destroy()
             self.topPanel.destroy()
-            if os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
+
+            if not deidentified_dcm and not original_dcm:
+                # if folder variables are not defined, then permission denied to create the folders
+                self.message.set("PERMISSION DENIED: cannot write in " + self.dirname)
+                self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
+                self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)
+            elif os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
+                # if paths exists, then return success message
                 self.message.set("BOOYA! It's de-identified!")
                 self.messageView.configure(fg="dark green", font= "Helvetica 16 bold italic")
                 self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E+W)
             else:
+                # if paths do not exists, then something went wrong
                 self.message.set("An error occured during DICOM files de-identification")
                 self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
                 self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -449,13 +449,12 @@ def mass_zapping(dicom_dict_list, verbose, xml_file_with_fields_to_zap):
 
         # get rid of '\ ' in DICOM path and map it to ' ' for the zapping method
         dicom_dir = row['dcm_dir'].replace('\ ', ' ')
-        (deidentified_dcm, original_dcm) = dicom_zapping(
-            dicom_dir, field_dict
-        )
+        (deidentified_dcm, original_dcm) = dicom_zapping(dicom_dir, field_dict)
 
         # check if deidentification was successful
-        if os.path.exists(deidentified_dcm) != [] and os.path.exists(
-                original_dcm) != []:
+        if not deidentified_dcm and not original_dcm:
+            error_arr.append(row['dcm_dir'] + ': Permission Denied')
+        elif os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
             success_arr.append(row['dcm_dir'])
         else:
             error_arr.append(row['dcm_dir'])

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -214,6 +214,8 @@ def dicom_zapping(dicom_folder, dicom_fields):
     (original_dir, deidentified_dir) = create_directories(dicom_folder,
                                                       dicom_fields,
                                                       subdirs_list)
+    if not original_dir and not deidentified_dir:
+        return None, None
 
     # Move DICOMs into the original_directory created and copy DICOMs into the
     # deidentified_folder
@@ -343,13 +345,19 @@ def create_directories(dicom_folder, dicom_fields, subdirs_list):
     patient_name     = dicom_fields['0010,0010']['Value'].strip()
     original_dir     = dicom_folder + os.path.sep + patient_name
     deidentified_dir = dicom_folder + os.path.sep + patient_name + "_deidentified"
-    os.mkdir(original_dir, 0o755)
-    os.mkdir(deidentified_dir, 0o755)
+    try:
+        os.mkdir(original_dir, 0o755)
+        os.mkdir(deidentified_dir, 0o755)
+    except OSError:
+        return None, None
     # Create subdirectories in original and de-identified directory, as found in
     # DICOM folder
     for subdir in subdirs_list:
-        os.mkdir(original_dir + os.path.sep + subdir, 0o755)
-        os.mkdir(deidentified_dir + os.path.sep + subdir, 0o755)
+        try:
+            os.mkdir(original_dir + os.path.sep + subdir, 0o755)
+            os.mkdir(deidentified_dir + os.path.sep + subdir, 0o755)
+        except OSError:
+            return None, None
 
     return original_dir, deidentified_dir
 


### PR DESCRIPTION
DICAT fails silently when a user does not have write privileges on the DICOM folder they want to de-identify. This fixes the issue and returns a proper error message to the user.